### PR TITLE
V2 main version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ReGWSWUSE
 Reprogramming project of GWSWUSE, submodel of WaterGAP. 
 # Branch description
-This is the first major version of the project.
+This is the second major version of the project.
 This version is configurable including cell-specific output.
-The aggregation of totals across all sectors works with unit harmonisation to m3/month direct in total_sectors_simulation.
-In this version back-converting to m3/year or m3/month is not necessary in output_data_postprocessing.
+
+In this version, it is not necessary to convert back to m3/year or m3/month in output_data_postprocessing, as all sector-specific results are calculated with input-unit.
+The harmonisation of the units for the aggregation of the results across all sectors is carried out directly in the calc_cross_sector_totals() function.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # ReGWSWUSE
 Reprogramming project of GWSWUSE, submodel of WaterGAP. 
+# Branch description
+This is the first major version of the project.
+This version is configurable including cell-specific output.
+The aggregation of totals across all sectors works with unit harmonisation to m3/month direct in total_sectors_simulation.
+In this version back-converting to m3/year or m3/month is not necessary in output_data_postprocessing.

--- a/model/domestic_simulation.py
+++ b/model/domestic_simulation.py
@@ -8,17 +8,24 @@
 # You should have received a copy of the LGPLv3 License along with WaterGAP.
 # if not see <https://www.gnu.org/licenses/lgpl-3.0>
 # =============================================================================
-
 """ GWSWUSE domestic simulation module."""
 
-import time
+import os
 import xarray as xr
 from controller import configuration_module as cm
 from model import model_equations as me
 from model import time_unit_conversion as tc
 
+# ===============================================================
+# Get module name and remove the .py extension
+# Module name is passed to logger
+# # =============================================================
+modname = os.path.basename(__file__)
+modname = modname.split('.')[0]
+
 
 class DomesticSimulator:
+    # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """
     Class to handle domestic water use simulations in the GWSWUSE model.
 
@@ -119,25 +126,10 @@ class DomesticSimulator:
         # Run the domestic simulation
         self.simulate_domestic()
 
-        print("Domestic simulation was performed. \n")
+        # print("Domestic simulation was performed. \n")
 
     def simulate_domestic(self):
-        """
-        Run the domestic simulation with provided data and model equations.
-        """
-        if cm.cell_specific_output['Flag']:
-            print('dom_cu_tot_m3_year:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_wu_tot_m3_year:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-        # Convert total consumptive use to m3/day
-        self.consumptive_use_tot = \
-            tc.convert_yearly_to_daily(self.consumptive_use_tot)
-
-        # Convert total abstraction to m3/day
-        self.abstraction_tot = \
-            tc.convert_yearly_to_daily(self.abstraction_tot)
-
+        """Run domestic simulation with provided data and model equations."""
         # Calc consumptive use from groundwater and surface water
         self.consumptive_use_gw, self.consumptive_use_sw = \
             me.calc_gwsw_water_use(self.consumptive_use_tot,
@@ -161,46 +153,79 @@ class DomesticSimulator:
                                          self.abstraction_sw,
                                          self.return_flow_sw)
 
+        # pylint: disable=consider-using-f-string
         if cm.cell_specific_output['Flag']:
-            print('dom_cu_tot_m3_day:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_wu_tot_m3_day:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_f_gw_use:'
-                  f'{self.fraction_gw_use[self.lat_idx, self.lon_idx]}')
-            print('dom_cu_gw_m3_day:'
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_cu_sw_m3_day:'
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_wu_gw_m3_day:'
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_wu_sw_m3_day:'
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_rf_tot_m3_day:'
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_f_gw_return:'
-                  f'{self.fraction_return_gw}')
-            print('dom_rf_gw_m3_day:'
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_rf_sw_m3_day:'
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_na_gw_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_na_sw_m3_day:'
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('dom_na_tot_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx] + self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
+            print('dom_consumptive_use_tot [m3/year]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                          self.lat_idx,
+                                          self.lon_idx]))
+
+            print('dom_abstraction_tot [m3/year]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                      self.lat_idx,
+                                      self.lon_idx]))
+
+            print('dom_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use[self.lat_idx,
+                                      self.lon_idx]))
+
+            print('dom_consumptive_use_gw [m3/year]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('dom_consumptive_use_sw [m3/year]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('dom_abstraction_gw [m3/year]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('dom_abstraction_sw [m3/year]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('dom_return_flow_tot [m3/year]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                      self.lat_idx,
+                                      self.lon_idx]))
+
+            print('dom_fraction_return_gw [-]: {}'.format(
+                self.fraction_return_gw))
+
+            print('dom_return_flow_gw [m3/year]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('dom_return_flow_sw [m3/year]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('dom_net_abstraction_gw [m3/year]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('dom_net_abstraction_sw [m3/year]: {} \n'.format(
+                    self.net_abstraction_sw[self.time_idx,
+                                            self.lat_idx,
+                                            self.lon_idx]))
 
 
-if __name__ == "__main__":
-    from controller import configuration_module as cm
-    from controller import input_data_manager as idm
+# if __name__ == "__main__":
+#     from controller import input_data_manager as idm
 
-    preprocessed_gwswuse_data, _, _, _ = \
-        idm.input_data_manager(cm.input_data_path,
-                               cm.gwswuse_convention_path,
-                               cm.start_year,
-                               cm.end_year,
-                               cm.time_extend_mode
-                               )
-    dom = DomesticSimulator(preprocessed_gwswuse_data['domestic'])
+#     preprocessed_gwswuse_data, _, _, _ = \
+#         idm.input_data_manager(cm.input_data_path,
+#                                cm.gwswuse_convention_path,
+#                                cm.start_year,
+#                                cm.end_year,
+#                                cm.time_extend_mode
+#                                )
+#     dom = DomesticSimulator(preprocessed_gwswuse_data['domestic'])

--- a/model/irrigation_simulation.py
+++ b/model/irrigation_simulation.py
@@ -8,14 +8,21 @@
 # You should have received a copy of the LGPLv3 License along with WaterGAP.
 # if not see <https://www.gnu.org/licenses/lgpl-3.0>
 # =============================================================================
-
 """ GWSWUSE irrigation simulation module."""
 
-import time
+import os
 import xarray as xr
 from controller import configuration_module as cm
 from model import model_equations as me
 from model import time_unit_conversion as tc
+
+
+# ===============================================================
+# Get module name and remove the .py extension
+# Module name is passed to logger
+# # =============================================================
+modname = os.path.basename(__file__)
+modname = modname.split('.')[0]
 
 
 class IrrigationSimulator:
@@ -107,7 +114,6 @@ class IrrigationSimulator:
             Dictionary containing xarray.DataArrays for various irrigation
             variables.
         """
-
         # Set total consumptive use input [m3/month]
         self.consumptive_use_tot = irr_data['consumptive_use_tot'].values
 
@@ -168,22 +174,16 @@ class IrrigationSimulator:
         # Run the irrigation simulation
         self.simulate_irrigation()
 
-        print("\nIrrigation simulation was performed. \n ")
+        # print("\nIrrigation simulation was performed. \n ")
 
     def simulate_irrigation(self):
-        """
-        Run the irrigation simulation with provided data and model equations.
-        """
+        """Run irrigation simulation with provided data and model equations."""
+        if cm.cell_specific_output['Flag']:
+            print('irr_consumptive_use_tot [m3/month]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                         self.lat_idx,
+                                         self.lon_idx]))
 
-        if cm.cell_specific_output['Flag']:
-            print('irr_cu_tot_m3_month: '
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-        # Convert total consumptive use to m3/day
-        self.consumptive_use_tot = \
-            tc.convert_monthly_to_daily(self.consumptive_use_tot)
-        if cm.cell_specific_output['Flag']:
-            print('irr_cu_tot_m3_day: '
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
         # Calc total consumptive use in irrigation for area actually irrigated
         self.consumptive_use_tot = \
             me.calc_irr_consumptive_use_aai(
@@ -193,8 +193,16 @@ class IrrigationSimulator:
                 )
 
         if cm.cell_specific_output['Flag'] and cm.irrigation_input_based_on_aei:
-            print('irr_cu_tot_m3_day corrected by fraction_aai_aei: '
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
+            print('fraction_aai_aei [-]: {}'.format(
+                self.fraction_aai_aei[self.time_idx,
+                                      self.lat_idx,
+                                      self.lon_idx]))
+
+            print('irr_consumptive_use_tot [m3/month] corrected by '
+                  'fraction_aai_aei: {}'.format(
+                      self.consumptive_use_tot[self.time_idx,
+                                               self.lat_idx,
+                                               self.lon_idx]))
 
         # Calc deficit total consumptive use in irrigation
         self.consumptive_use_tot = \
@@ -203,15 +211,24 @@ class IrrigationSimulator:
                 self.deficit_irrigation_location,
                 cm.deficit_irrigation_mode
                 )
+
         if cm.cell_specific_output['Flag'] and cm.deficit_irrigation_mode:
-            print('gwd_mask: '
-                  f'{self.gwd_mask[self.lat_idx, self.lon_idx]}')
-            print('abstraction_irr_part_mask: '
-                  f'{self.abstraction_irr_part_mask[self.lat_idx, self.lon_idx]}')
-            print('deficit_irrigation_factor: '
-                  f'{self.deficit_irrigation_location[self.lat_idx, self.lon_idx]}')
-            print('irr_cu_tot_deficit_m3_day: '
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
+            print('gwd_mask [bool]: {}'.format(
+                self.gwd_mask[self.lat_idx,
+                              self.lon_idx]))
+
+            print('abstraction_irr_part_mask [bool]: {}'.format(
+                self.abstraction_irr_part_mask[self.lat_idx,
+                                               self.lon_idx]))
+
+            print('deficit_irrigation_factor [-]: {}'.format(
+                self.deficit_irrigation_location[self.lat_idx,
+                                                 self.lon_idx]))
+
+            print('irr_consumptive_use_tot_deficit [m3/month]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                         self.lat_idx,
+                                         self.lon_idx]))
 
         # Correct total consumptive use by time dev for area actually irrigated
         self.consumptive_use_tot = \
@@ -222,10 +239,16 @@ class IrrigationSimulator:
                 )
 
         if cm.cell_specific_output['Flag'] and cm.correct_irr_t_aai_mode:
-            print('t_aai: '
-                  f'{self.time_factor_aai[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_cu_tot_m3_day corrected by t_aai: '
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
+            print('time_factor_aai [-]: {}'.format(
+                self.time_factor_aai[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('irr_consumptive_use_tot [m3/month] corrected by '
+                  'time_factor_aai: {}'.format(
+                      self.consumptive_use_tot[self.time_idx,
+                                               self.lat_idx,
+                                               self.lon_idx]))
 
         # Calc consumptive use from groundwater and surface water
         self.consumptive_use_gw, self.consumptive_use_sw = \
@@ -233,44 +256,19 @@ class IrrigationSimulator:
                 self.consumptive_use_tot,
                 self.fraction_gw_use
                 )
-        if cm.cell_specific_output['Flag']:
-            print('irr_f_gw_use: '
-                  f'{self.fraction_gw_use[self.lat_idx, self.lon_idx]}')
-            print('irr_cu_gw_m3_day: '
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_cu_sw_m3_day: '
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
+
         # Calc total and split abstractions for groundwater and surface water
         self.abstraction_gw, self.abstraction_sw, self.abstraction_tot = \
             me.calc_irr_abstraction_totgwsw(self.consumptive_use_gw,
                                             self.irrigation_efficiency_gw,
                                             self.consumptive_use_sw,
                                             self.irrigation_efficiency_sw)
-        if cm.cell_specific_output['Flag']:
-            print('irr_eff_gw: '
-                  f'{self.irrigation_efficiency_gw[self.lat_idx, self.lon_idx]}')
-            print('irr_wu_gw_m3_day: '
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_eff_sw: '
-                  f'{self.irrigation_efficiency_sw[self.lat_idx, self.lon_idx]}')
-            print('irr_wu_sw_m3_day: '
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_wu_tot_m3_day: '
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
+
         # Calc and split return flows to groundwater and surface water
         self.return_flow_tot, self.return_flow_gw, self.return_flow_sw = \
             me.calc_return_flow_totgwsw(self.abstraction_tot,
                                         self.consumptive_use_tot,
                                         self.fraction_return_gw)
-        if cm.cell_specific_output['Flag']:
-            print('irr_rf_tot_m3_day: '
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_f_gw_return: '
-                  f'{self.fraction_return_gw[self.lat_idx, self.lon_idx]}')
-            print('irr_rf_gw_m3_day: '
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_rf_sw_m3_day: '
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
 
         # Calc net abstractions from groundwater and surface water
         self.net_abstraction_gw, self.net_abstraction_sw = \
@@ -278,17 +276,73 @@ class IrrigationSimulator:
                                          self.return_flow_gw,
                                          self.abstraction_sw,
                                          self.return_flow_sw)
+
         if cm.cell_specific_output['Flag']:
-            print('irr_na_gw_m3_day: '
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_na_sw_m3_day: '
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('irr_na_tot_m3_day: '
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx] + self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
+            print('irr_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use[self.lat_idx,
+                                     self.lon_idx]))
+
+            print('irr_consumptive_use_gw [m3/month]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('irr_consumptive_use_sw [m3/month]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+            print('irr_efficiency_gw [-]: {}'.format(
+                self.irrigation_efficiency_gw[self.lat_idx,
+                                              self.lon_idx]))
+
+            print('irr_abstraction_gw [m3/month]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('irr_efficiency_sw [-]: {}'.format(
+                self.irrigation_efficiency_sw[self.lat_idx,
+                                              self.lon_idx]))
+
+            print('irr_abstraction_sw [m3/month]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('irr_abstraction_tot [m3/month]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+            print('irr_return_flow_tot [m3/month]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('irr_fraction_return_gw [-]: {}'.format(
+                self.fraction_return_gw[self.lat_idx, self.lon_idx]))
+
+            print('irr_return_flow_gw [m3/month]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('irr_return_flow_sw [m3/month]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('irr_net_abstraction_gw [m3/month]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('irr_net_abstraction_sw [m3/month]: {}'.format(
+                self.net_abstraction_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
 
 
 if __name__ == "__main__":
-    # from controller import configuration_module as cm
     from controller import input_data_manager as idm
 
     preprocessed_gwswuse_data, _, _, _ = \

--- a/model/livestock_simulation.py
+++ b/model/livestock_simulation.py
@@ -8,16 +8,22 @@
 # You should have received a copy of the LGPLv3 License along with WaterGAP.
 # if not see <https://www.gnu.org/licenses/lgpl-3.0>
 # =============================================================================
-
 """ GWSWUSE livestock simulation module."""
 
-import time
+import os
 import xarray as xr
 from controller import configuration_module as cm
 from model import model_equations as me
 from model import time_unit_conversion as tc
 
+# ===============================================================
+# Get module name and remove the .py extension
+# Module name is passed to logger
+# # =============================================================
+modname = os.path.basename(__file__)
+modname = modname.split('.')[0]
 
+    
 class LivestockSimulator:
     """
     Class to handle livestock water use simulations in the GWSWUSE model.
@@ -124,25 +130,10 @@ class LivestockSimulator:
         # Run the irrigation simulation
         self.simulate_livestock()
 
-        print("Livestock simulation was performed. \n")
+        # print("Livestock simulation was performed. \n")
 
     def simulate_livestock(self):
-        """
-        Run the livestock simulation with provided data and model equations.
-        """
-        if cm.cell_specific_output['Flag']:
-            print('liv_cu_tot_m3_year:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_wu_tot_m3_year:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-        # Convert total consumptive use to m3/day
-        self.consumptive_use_tot = \
-            tc.convert_yearly_to_daily(self.consumptive_use_tot)
-
-        # Convert total abstraction to m3/day
-        self.abstraction_tot = \
-            tc.convert_yearly_to_daily(self.abstraction_tot)
-
+        """Run livestock simulation with provided data and model equations."""
         # Calc consumptive use from groundwater and surface water
         self.consumptive_use_gw, self.consumptive_use_sw = \
             me.calc_gwsw_water_use(self.consumptive_use_tot,
@@ -167,47 +158,76 @@ class LivestockSimulator:
                                          self.return_flow_sw)
 
         if cm.cell_specific_output['Flag']:
-            print('liv_cu_tot_m3_day:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_wu_tot_m3_day:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_f_gw_use:'
-                  f'{self.fraction_gw_use}')
-            print('liv_cu_gw_m3_day:'
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_cu_sw_m3_day:'
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_wu_gw_m3_day:'
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_wu_sw_m3_day:'
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_rf_tot_m3_day:'
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_f_gw_return:'
-                  f'{self.fraction_return_gw}')
-            print('liv_rf_gw_m3_day:'
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_rf_sw_m3_day:'
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_na_gw_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_na_sw_m3_day:'
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('liv_na_tot_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx] + self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
+            print('liv_consumptive_use_tot [m3/year]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                         self.lat_idx,
+                                         self.lon_idx]))
 
+            print('liv_abstraction_tot [m3/year]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('liv_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use))
+
+            print('liv_consumptive_use_gw [m3/year]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('liv_consumptive_use_sw [m3/year]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('liv_abstraction_gw [m3/year]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('liv_abstraction_sw [m3/year]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('liv_return_flow_tot [m3/year]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('liv_fraction_return_gw [-]: {}'.format(
+                self.fraction_return_gw))
+
+            print('liv_return_flow_gw [m3/year]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('liv_return_flow_sw [m3/year]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('liv_net_abstraction_gw [m3/year]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('liv_net_abstraction_sw [m3/year]: {} \n'.format(
+                    self.net_abstraction_sw[self.time_idx,
+                                            self.lat_idx,
+                                            self.lon_idx]))
 
 
 if __name__ == "__main__":
-    from controller import configuration_module as cm
-    from controller import input_data_manager as idm
+    from controller.input_data_manager import input_data_manager
 
     preprocessed_gwswuse_data, _, _, _ = \
-        idm.input_data_manager(cm.input_data_path,
-                               cm.gwswuse_convention_path,
-                               cm.start_year,
-                               cm.end_year,
-                               cm.time_extend_mode,
-                               cm.correct_irr_with_t_aai_mode
-                               )
+        input_data_manager(cm.input_data_path,
+                           cm.gwswuse_convention_path,
+                           cm.start_year,
+                           cm.end_year,
+                           cm.time_extend_mode
+                           )
     liv = LivestockSimulator(preprocessed_gwswuse_data['livestock'])

--- a/model/manufacturing_simulation.py
+++ b/model/manufacturing_simulation.py
@@ -11,11 +11,19 @@
 
 """ GWSWUSE manufacturing simulation module."""
 
-import time
+import os
 import xarray as xr
 from controller import configuration_module as cm
 from model import model_equations as me
 from model import time_unit_conversion as tc
+
+
+# ===============================================================
+# Get module name and remove the .py extension
+# Module name is passed to logger
+# # =============================================================
+modname = (os.path.basename(__file__))
+modname = modname.split('.')[0]
 
 
 class ManufacturingSimulator:
@@ -121,24 +129,12 @@ class ManufacturingSimulator:
         # Run the irrigation simulation
         self.simulate_manufacturing()
 
-        print("Manufacturing simulation was performed. \n")
+        # print("Manufacturing simulation was performed. \n")
 
     def simulate_manufacturing(self):
         """
         Run manufacturing simulation with provided data and model equations.
         """
-        if cm.cell_specific_output['Flag']:
-            print('man_cu_tot_m3_year:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_wu_tot_m3_year:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-        # Convert total consumptive use to m3/day
-        self.consumptive_use_tot = \
-            tc.convert_yearly_to_daily(self.consumptive_use_tot)
-
-        # Convert total abstraction to m3/day
-        self.abstraction_tot = \
-            tc.convert_yearly_to_daily(self.abstraction_tot)
 
         # Calc consumptive use from groundwater and surface water
         self.consumptive_use_gw, self.consumptive_use_sw = \
@@ -164,39 +160,70 @@ class ManufacturingSimulator:
                                          self.return_flow_sw)
 
         if cm.cell_specific_output['Flag']:
-            print('man_cu_tot_m3_day:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_wu_tot_m3_day:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_f_gw_use:'
-                  f'{self.fraction_gw_use[self.lat_idx, self.lon_idx]}')
-            print('man_cu_gw_m3_day:'
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_cu_sw_m3_day:'
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_wu_gw_m3_day:'
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_wu_sw_m3_day:'
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_rf_tot_m3_day:'
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_f_gw_return:'
-                  f'{self.fraction_return_gw}')
-            print('man_rf_gw_m3_day:'
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_rf_sw_m3_day:'
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_na_gw_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_na_sw_m3_day:'
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('man_na_tot_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx] + self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
+            print('man_consumptive_use_tot [m3/year]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                         self.lat_idx,
+                                         self.lon_idx]))
 
+            print('man_abstraction_tot [m3/year]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('man_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use[self.lat_idx,
+                                     self.lon_idx]))
+
+            print('man_consumptive_use_gw [m3/year]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('man_consumptive_use_sw [m3/year]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('man_abstraction_gw [m3/year]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('man_abstraction_sw [m3/year]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('man_return_flow_tot [m3/year]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('man_fraction_return_gw [-]: {}'.format(
+                self.fraction_return_gw))
+
+            print('man_return_flow_gw [m3/year]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('man_return_flow_sw [m3/year]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('man_net_abstraction_gw [m3/year]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('man_net_abstraction_sw [m3/year]: {} \n'.format(
+                    self.net_abstraction_sw[self.time_idx,
+                                            self.lat_idx,
+                                            self.lon_idx]))
 
 
 if __name__ == "__main__":
-    from controller import configuration_module as cm
     from controller import input_data_manager as idm
 
     preprocessed_gwswuse_data, _, _, _ = \

--- a/model/model_equations.py
+++ b/model/model_equations.py
@@ -413,6 +413,7 @@ def calc_irr_abstraction_totgwsw(irr_consumptive_use_gw, irr_efficiency_gw,
         Irrigation-specific consumptive water use from groundwater.
     irr_efficiency_gw : numpy.ndarray or float
         Irrigation efficiency for groundwater.
+
     Returns
     -------
     irr_abstraction_gw : numpy.ndarray
@@ -435,60 +436,6 @@ def calc_irr_abstraction_totgwsw(irr_consumptive_use_gw, irr_efficiency_gw,
 #            =======================================
 #            || CROSS-SECTOR SIMULATION FUNCTIONS ||
 #            =======================================
-
-
-def sum_volume_per_time_variable(irr_monthly,
-                                 dom_annual,
-                                 man_annual,
-                                 tp_annual,
-                                 liv_annual):
-    """
-    Sum the volume per time variable for multiple sectors.
-
-    This function calculates the total volume per time variable for multiple
-    sectors by summing the monthly values of irrigation (m³/day), domestic,
-    manufacturing, thermal power, and livestock sectors.
-
-    The volume-per-time variables for which the function is intended are:
-    - Consumptive use from groundwater (consumptive_use_gw), surface water
-      (consumptive_use_sw) or both (consumptive_use_tot).
-    - Water abstraction from groundwater (abstraction_gw), surface water
-      (abstraction_sw) or both (abstraction_tot).
-    - Return flow (rf) to groundwater (return_flow_gw), surface water
-      (return_flow_sw) or both (return_flow_tot).
-    - Net abstractions from groundwater (net_abstraction_gw) or surface water
-      (net_abstraction_sw).
-
-    Parameters
-    ----------
-    irr_monthly : numpy.ndarray
-        Monthly irrigation data array (m³/day).
-    dom_annual : numpy.ndarray
-        Annual domestic data array (m³/day).
-    man_annual : numpy.ndarray
-        Annual manufacturing data array (m³/day).
-    tp_annual : numpy.ndarray
-        Annual thermal power data array (m³/day).
-    liv_annual : numpy.ndarray
-        Annual livestock data array (m³/day).
-
-    Returns
-    -------
-    total_sectors_monthly : numpy.ndarray
-        Total volume per time variable for all sectors combined, represented as
-        a monthly data array (m³/day).
-
-    """
-    dom_man_tp_liv_sum_annual = \
-        dom_annual + man_annual + tp_annual + liv_annual
-
-    dom_man_tp_liv_sum_monthly = \
-        tc.expand_array_size(dom_man_tp_liv_sum_annual)
-
-    total_sectors_monthly = \
-        irr_monthly + dom_man_tp_liv_sum_monthly
-
-    return total_sectors_monthly
 
 
 def calculate_cross_sector_totals(irr_monthly_m3_month,

--- a/model/model_equations.py
+++ b/model/model_equations.py
@@ -12,18 +12,15 @@
 """GWSWUSE model equations for numpy arrays."""
 
 import os
-# import logging
 from numba import njit
-# import xarray as xr
 import numpy as np
-# import watergap_logger as log
 from model import time_unit_conversion as tc
 
-# ===============================================================aqq
+# =================================================================
 # Get module name and remove the .py extension
 # Module name is passed to logger
 # # ===============================================================
-modname = (os.path.basename(__file__))
+modname = os.path.basename(__file__)
 modname = modname.split('.')[0]
 
 

--- a/model/thermal_power_simulation.py
+++ b/model/thermal_power_simulation.py
@@ -12,14 +12,22 @@
 """ GWSWUSE thermal power simulation module."""
 # from source.controller import configuration_module as cm
 
-import time
+import os
 import xarray as xr
 from controller import configuration_module as cm
 from model import model_equations as me
 from model import time_unit_conversion as tc
 
+# ===============================================================
+# Get module name and remove the .py extension
+# Module name is passed to logger
+# # =============================================================
+modname = (os.path.basename(__file__))
+modname = modname.split('.')[0]
+
 
 class ThermalPowerSimulator:
+    # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """
     Class to handle thermal power water use simulations in the GWSWUSE model.
 
@@ -123,25 +131,12 @@ class ThermalPowerSimulator:
         # Run the irrigation simulation
         self.simulate_thermal_power()
 
-        print("Thermal power simulation was performed. \n")
+        # print("Thermal power simulation was performed. \n")
 
     def simulate_thermal_power(self):
         """
         Run thermal power simulation with provided data and model equations.
         """
-        if cm.cell_specific_output['Flag']:
-            print('tp_cu_tot_m3_year:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_wu_tot_m3_year:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-        # Convert total consumptive use to m3/day
-        self.consumptive_use_tot = \
-            tc.convert_yearly_to_daily(self.consumptive_use_tot)
-
-        # Convert total abstraction to m3/day
-        self.abstraction_tot = \
-            tc.convert_yearly_to_daily(self.abstraction_tot)
-
         # Calc consumptive use from groundwater and surface water
         self.consumptive_use_gw, self.consumptive_use_sw = \
             me.calc_gwsw_water_use(self.consumptive_use_tot,
@@ -164,41 +159,71 @@ class ThermalPowerSimulator:
                                          self.return_flow_gw,
                                          self.abstraction_sw,
                                          self.return_flow_sw)
-
+            
         if cm.cell_specific_output['Flag']:
-            print('tp_cu_tot_m3_day:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_wu_tot_m3_day:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_f_gw_use:'
-                  f'{self.fraction_gw_use}')
-            print('tp_cu_gw_m3_day:'
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_cu_sw_m3_day:'
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_wu_gw_m3_day:'
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_wu_sw_m3_day:'
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_rf_tot_m3_day:'
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_f_gw_return:'
-                  f'{self.fraction_return_gw}')
-            print('tp_rf_gw_m3_day:'
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_rf_sw_m3_day:'
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_na_gw_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_na_sw_m3_day:'
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('tp_na_tot_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx] + self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
+            print('tp_consumptive_use_tot [m3/year]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                          self.lat_idx,
+                                          self.lon_idx]))
 
+            print('tp_abstraction_tot [m3/year]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                      self.lat_idx,
+                                      self.lon_idx]))
+
+            print('tp_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use))
+
+            print('tp_consumptive_use_gw [m3/year]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('tp_consumptive_use_sw [m3/year]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('tp_abstraction_gw [m3/year]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('tp_abstraction_sw [m3/year]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('tp_return_flow_tot [m3/year]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                      self.lat_idx,
+                                      self.lon_idx]))
+
+            print('tp_fraction_return_gw [-]: {}'.format(
+                self.fraction_return_gw))
+
+            print('tp_return_flow_gw [m3/year]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('tp_return_flow_sw [m3/year]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('tp_net_abstraction_gw [m3/year]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('tp_net_abstraction_sw [m3/year]: {} \n'.format(
+                    self.net_abstraction_sw[self.time_idx,
+                                            self.lat_idx,
+                                            self.lon_idx]))
 
 
 if __name__ == "__main__":
-    from controller import configuration_module as cm
     from controller import input_data_manager as idm
 
     preprocessed_gwswuse_data, _, _, _ = \
@@ -206,7 +231,7 @@ if __name__ == "__main__":
                                cm.gwswuse_convention_path,
                                cm.start_year,
                                cm.end_year,
-                               cm.time_extend_mode,
-                               cm.correct_irr_with_t_aai_mode
+                               cm.time_extend_mode
+                               # cm.correct_irr_with_t_aai_mode
                                )
     tp = ThermalPowerSimulator(preprocessed_gwswuse_data['thermal_power'])

--- a/model/total_sectors_simulation.py
+++ b/model/total_sectors_simulation.py
@@ -12,7 +12,6 @@
 """ GWSWUSE total sectors simulation module."""
 
 import os
-import time
 
 from controller import configuration_module as cm
 from model import model_equations as me
@@ -21,11 +20,12 @@ from model import model_equations as me
 # Get module name and remove the .py extension
 # Module name is passed to logger
 # # =============================================================
-modname = (os.path.basename(__file__))
+modname = os.path.basename(__file__)
 modname = modname.split('.')[0]
 
 
 class TotalSectorsSimulator():
+    # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """
     Sum sector-specific volume per time variables across all sectors.
 
@@ -94,87 +94,83 @@ class TotalSectorsSimulator():
         liv : SectorData
             Livestock sector data.
         """
-        start_time = time.time()
-
         # Sum total consumptive use across all sectors
         self.consumptive_use_tot = \
-            me.sum_volume_per_time_variable(irr.consumptive_use_tot,
-                                            dom.consumptive_use_tot,
-                                            man.consumptive_use_tot,
-                                            tp.consumptive_use_tot,
-                                            liv.consumptive_use_tot)
+            me.calculate_cross_sector_totals(irr.consumptive_use_tot,
+                                             dom.consumptive_use_tot,
+                                             man.consumptive_use_tot,
+                                             tp.consumptive_use_tot,
+                                             liv.consumptive_use_tot)
         # Sum consumptive use of groundwater across all sectors
         self.consumptive_use_gw = \
-            me.sum_volume_per_time_variable(irr.consumptive_use_gw,
-                                            dom.consumptive_use_gw,
-                                            man.consumptive_use_gw,
-                                            tp.consumptive_use_gw,
-                                            liv.consumptive_use_gw)
+            me.calculate_cross_sector_totals(irr.consumptive_use_gw,
+                                             dom.consumptive_use_gw,
+                                             man.consumptive_use_gw,
+                                             tp.consumptive_use_gw,
+                                             liv.consumptive_use_gw)
         # Sum consumptive use of surface water across all sectors
         self.consumptive_use_sw = \
-            me.sum_volume_per_time_variable(irr.consumptive_use_sw,
-                                            dom.consumptive_use_sw,
-                                            man.consumptive_use_sw,
-                                            tp.consumptive_use_sw,
-                                            liv.consumptive_use_sw)
+            me.calculate_cross_sector_totals(irr.consumptive_use_sw,
+                                             dom.consumptive_use_sw,
+                                             man.consumptive_use_sw,
+                                             tp.consumptive_use_sw,
+                                             liv.consumptive_use_sw)
         # Sum total abstraction of water across all sectors
         self.abstraction_tot = \
-            me.sum_volume_per_time_variable(irr.abstraction_tot,
-                                            dom.abstraction_tot,
-                                            man.abstraction_tot,
-                                            tp.abstraction_tot,
-                                            liv.abstraction_tot)
+            me.calculate_cross_sector_totals(irr.abstraction_tot,
+                                             dom.abstraction_tot,
+                                             man.abstraction_tot,
+                                             tp.abstraction_tot,
+                                             liv.abstraction_tot)
         # Sum abstraction of groundwater across all sectors
         self.abstraction_gw = \
-            me.sum_volume_per_time_variable(irr.abstraction_gw,
-                                            dom.abstraction_gw,
-                                            man.abstraction_gw,
-                                            tp.abstraction_gw,
-                                            liv.abstraction_gw)
+            me.calculate_cross_sector_totals(irr.abstraction_gw,
+                                             dom.abstraction_gw,
+                                             man.abstraction_gw,
+                                             tp.abstraction_gw,
+                                             liv.abstraction_gw)
         # Sum abstraction of surface water across all sectors
         self.abstraction_sw = \
-            me.sum_volume_per_time_variable(irr.abstraction_sw,
-                                            dom.abstraction_sw,
-                                            man.abstraction_sw,
-                                            tp.abstraction_sw,
-                                            liv.abstraction_sw)
+            me.calculate_cross_sector_totals(irr.abstraction_sw,
+                                             dom.abstraction_sw,
+                                             man.abstraction_sw,
+                                             tp.abstraction_sw,
+                                             liv.abstraction_sw)
         # Sum total return flow across all sectors
         self.return_flow_tot = \
-            me.sum_volume_per_time_variable(irr.return_flow_tot,
-                                            dom.return_flow_tot,
-                                            man.return_flow_tot,
-                                            tp.return_flow_tot,
-                                            liv.return_flow_tot)
+            me.calculate_cross_sector_totals(irr.return_flow_tot,
+                                             dom.return_flow_tot,
+                                             man.return_flow_tot,
+                                             tp.return_flow_tot,
+                                             liv.return_flow_tot)
         # Sum return flow to groundwater across all sectors
         self.return_flow_gw = \
-            me.sum_volume_per_time_variable(irr.return_flow_gw,
-                                            dom.return_flow_gw,
-                                            man.return_flow_gw,
-                                            tp.return_flow_gw,
-                                            liv.return_flow_gw)
+            me.calculate_cross_sector_totals(irr.return_flow_gw,
+                                             dom.return_flow_gw,
+                                             man.return_flow_gw,
+                                             tp.return_flow_gw,
+                                             liv.return_flow_gw)
         # Sum return flow to surface water across all sectors
         self.return_flow_sw = \
-            me.sum_volume_per_time_variable(irr.return_flow_sw,
-                                            dom.return_flow_sw,
-                                            man.return_flow_sw,
-                                            tp.return_flow_sw,
-                                            liv.return_flow_sw)
+            me.calculate_cross_sector_totals(irr.return_flow_sw,
+                                             dom.return_flow_sw,
+                                             man.return_flow_sw,
+                                             tp.return_flow_sw,
+                                             liv.return_flow_sw)
         # Sum net abstraction of groundwater across all sectors
         self.net_abstraction_gw = \
-            me.sum_volume_per_time_variable(irr.net_abstraction_gw,
-                                            dom.net_abstraction_gw,
-                                            man.net_abstraction_gw,
-                                            tp.net_abstraction_gw,
-                                            liv.net_abstraction_gw)
+            me.calculate_cross_sector_totals(irr.net_abstraction_gw,
+                                             dom.net_abstraction_gw,
+                                             man.net_abstraction_gw,
+                                             tp.net_abstraction_gw,
+                                             liv.net_abstraction_gw)
         # Sum net abstraction of surface water across all sectors
         self.net_abstraction_sw = \
-            me.sum_volume_per_time_variable(irr.net_abstraction_sw,
-                                            dom.net_abstraction_sw,
-                                            man.net_abstraction_sw,
-                                            tp.net_abstraction_sw,
-                                            liv.net_abstraction_sw)
-        self.net_abstraction_tot = \
-            self.net_abstraction_gw + self.net_abstraction_sw
+            me.calculate_cross_sector_totals(irr.net_abstraction_sw,
+                                             dom.net_abstraction_sw,
+                                             man.net_abstraction_sw,
+                                             tp.net_abstraction_sw,
+                                             liv.net_abstraction_sw)
 
         # Calc fractions of groundwater use across all sectors
         self.fraction_gw_use, self.fraction_return_gw = \
@@ -185,46 +181,78 @@ class TotalSectorsSimulator():
         # Store coords for generating netcdf-output
         self.coords = irr.coords
         if cm.cell_specific_output['Flag']:
-            print("Total specific values for "
-                  f"lat: {cm.cell_specific_output['coords']['lat']}, "
-                  f"lon: {cm.cell_specific_output['coords']['lon']},"
-                  f"year: {cm.cell_specific_output['coords']['year']}, "
-                  f"month: {cm.cell_specific_output['coords']['month']}")
+            print("Total specific values for lat: {lat}, lon: {lon}, "
+                  "year: {year}, month: {month}".format(
+                      lat=cm.cell_specific_output['coords']['lat'],
+                      lon=cm.cell_specific_output['coords']['lon'],
+                      year=cm.cell_specific_output['coords']['year'],
+                      month=cm.cell_specific_output['coords']['month']
+                  ))
             self.time_idx = irr.time_idx
             self.lat_idx = irr.lat_idx
             self.lon_idx = irr.lon_idx
-            print('total_cu_tot_m3_day:'
-                  f'{self.consumptive_use_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_cu_gw_m3_day:'
-                  f'{self.consumptive_use_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_cu_sw_m3_day:'
-                  f'{self.consumptive_use_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_wu_tot_m3_day:'
-                  f'{self.abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_wu_gw_m3_day:'
-                  f'{self.abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_wu_sw_m3_day:'
-                  f'{self.abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_rf_tot_m3_day:'
-                  f'{self.return_flow_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_rf_gw_m3_day:'
-                  f'{self.return_flow_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_rf_sw_m3_day:'
-                  f'{self.return_flow_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_na_gw_m3_day:'
-                  f'{self.net_abstraction_gw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_na_sw_m3_day:'
-                  f'{self.net_abstraction_sw[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_na_tot_m3_day:'
-                  f'{self.net_abstraction_tot[self.time_idx, self.lat_idx, self.lon_idx]}')
 
-            print('total_f_gw_use:'
-                  f'{self.fraction_gw_use[self.time_idx, self.lat_idx, self.lon_idx]}')
-            print('total_f_gw_return:'
-                  f'{self.fraction_return_gw[self.time_idx, self.lat_idx, self.lon_idx]}\n')
-            
-            
-            
+            print('total_consumptive_use_tot [m3/month]: {}'.format(
+                self.consumptive_use_tot[self.time_idx,
+                                         self.lat_idx,
+                                         self.lon_idx]))
 
-        end_time = time.time()  # Endzeit messen
-        print("Cross-sector total simulation was performed. \n")
+            print('total_consumptive_use_gw [m3/month]: {}'.format(
+                self.consumptive_use_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('total_consumptive_use_sw [m3/month]: {}'.format(
+                self.consumptive_use_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('total_abstraction_tot [m3/month]: {}'.format(
+                self.abstraction_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('total_abstraction_gw [m3/month]: {}'.format(
+                self.abstraction_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('total_abstraction_sw [m3/month]: {}'.format(
+                self.abstraction_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('total_rf_tot [m3/month]: {}'.format(
+                self.return_flow_tot[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('total_rf_gw [m3/month]: {}'.format(
+                self.return_flow_gw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('total_rf_sw [m3/month]: {}'.format(
+                self.return_flow_sw[self.time_idx,
+                                    self.lat_idx,
+                                    self.lon_idx]))
+
+            print('total_net_abstraction_gw [m3/month]: {}'.format(
+                self.net_abstraction_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('total_net_abstraction_sw [m3/month]: {}'.format(
+                self.net_abstraction_sw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))
+
+            print('total_fraction_gw_use [-]: {}'.format(
+                self.fraction_gw_use[self.time_idx,
+                                     self.lat_idx,
+                                     self.lon_idx]))
+
+            print('total_fraction_return_gw [-]: {} \n'.format(
+                self.fraction_return_gw[self.time_idx,
+                                        self.lat_idx,
+                                        self.lon_idx]))

--- a/view/output_data_postprocessing.py
+++ b/view/output_data_postprocessing.py
@@ -19,9 +19,8 @@ import xarray as xr
 from termcolor import colored
 from colorama import init
 
-from controller import configuration_module as cm
 from model import time_unit_conversion as tc
-from view import regwswuse_var_info as var_info
+from view import gwswuse_var_info as var_info
 from misc import watergap_version
 
 
@@ -31,7 +30,7 @@ init()
 # =============================================================================
 
 
-def write_to_xr_dataarray(result_np, coords, variable_name, sector):
+def write_to_xr_dataarray(result_np, coords, var_name, sector):
     """
     Write the model results contained in a NumPy array to an xarray dataset.
 
@@ -46,7 +45,7 @@ def write_to_xr_dataarray(result_np, coords, variable_name, sector):
         A dictionary of coordinates (latitude, longitude, and for some
         variables also time) used for the xarray dataset. This dictionary sets
         the spatial and temporal dimensions for the data.
-    variable_name : str
+    var_name : str
         The name of the variable to be stored in the xarray dataset.
     sector : str
         The sector associated with the variable, used for metadata.
@@ -56,35 +55,25 @@ def write_to_xr_dataarray(result_np, coords, variable_name, sector):
     xr.DataArray
         An xarray dataset with the model results and appropriate metadata.
     """
-    monthly_sector = ['irrigation', 'total']
     special_vars = ['irrigation_efficiency_gw',
                     'irrigation_efficiency_sw',
                     'deficit_irrigation_location']
 
-    if variable_name in special_vars:
+    if var_name in special_vars:
         # select only 'lat' & 'lon' as coordinates
         coords = {key: coords[key] for key in ['lat', 'lon']}
         result_xr = xr.Dataset(coords=coords)
     else:
-        if sector in monthly_sector:
-            # convert to m3/month
-            result_np = tc.convert_daily_to_monthly(result_np)
-            result_np = result_np
-        else:
-            # convert to m3/year
-            result_np = result_np * 365.0
         result_xr = xr.Dataset(coords=coords)
         result_xr = result_xr.chunk({'time': 1, 'lat': 360, 'lon': 720})
 
-    variable_metadata = set_variable_metadata_xr(sector, variable_name)
+    variable_metadata = set_variable_metadata_xr(sector, var_name)
     xr_var_name = variable_metadata['standard_name']
     del variable_metadata['standard_name']
 
     result_xr[xr_var_name] = \
         xr.DataArray(result_np, coords=coords)
     result_xr[xr_var_name].attrs = variable_metadata
-
-    # result_xr = set_dimension_attributes(result_xr, sector)
 
     result_xr.attrs = set_global_metadata()
 
@@ -132,7 +121,7 @@ def set_variable_metadata_xr(sector, var):
         return var_info.modelvars[var][sector]
 
 
-def set_dimension_attributes(xr_array, sector):
+def set_dimension_attributes(xr_array, sector, start_year):
     """
     Set the attributes of the dimensions of an xarray DataArray.
 
@@ -152,7 +141,6 @@ def set_dimension_attributes(xr_array, sector):
         timestep = 'Months'
     else:
         timestep = 'Years'
-    start_year = cm.start_year
     # Create attribute dictionairy for dimensions
     dim_attributes = {
         'time': {
@@ -331,8 +319,10 @@ def sum_global_annual_totals(sectors_dict, start_year, end_year):
         'return_flow_tot', 'return_flow_gw', 'return_flow_sw',
         'net_abstraction_gw', 'net_abstraction_sw'
     ]
+    # List sectors with monthly time resolution
+    monthly_sectors = ['irrigation', 'total']
 
-    print('\n' + colored(f'Global Totals for year {cm.start_year}', 'cyan'))
+    print('\n' + colored(f'Global Totals for year {start_year}', 'cyan'))
     # Iterate over each variable in the list
     for var_name in global_annual_totals_vars:
         # Create an empty dataframe to store annual totals for each sector
@@ -343,14 +333,10 @@ def sum_global_annual_totals(sectors_dict, start_year, end_year):
             # Get the array of values for the current variable and sector
             var_array = getattr(sectors_dict[sector], var_name)
 
-            # Determine the time step and number of simulation years
-            time_step, sim_num_years = tc.get_time_step_in_array(
-                var_array, start_year, end_year
-            )
-
-            # Convert daily values to yearly values
-            var_array = \
-                tc.convert_daily_to_yearly(var_array, start_year, end_year)
+            if sector in monthly_sectors:
+                # Convert daily values to yearly values
+                var_array = \
+                    tc.convert_monthly_to_yearly(var_array)
 
             # Sum the values across the lat and lon dimensions for annual
             # totals


### PR DESCRIPTION
In this merger, the unit harmonisation via m3/day in the sector-specific simulators was deleted in ReGWSWUSE. 
Instead, the annual values in the unit m3/year are now only converted into monthly values with the unit m3/month for the cross-sector aggregation (convert_yearly_to_monthly, calculate_cross_sector_totals).
This reduces floating point errors because the sector-specific results are no longer converted back to their original unit for the NetCDF output, and the cross-sector results no longer need to be converted to m3/month. 
For the global, annual totals, the function convert_monthly_to_yearly was developed to convert the monthly values for the irrigation sector and the total across sectors into annual values in the unit m3/year.